### PR TITLE
LAV Splitter API: Add a function to get the list of available formats

### DIFF
--- a/common/includes/LAVSplitterSettings.h
+++ b/common/includes/LAVSplitterSettings.h
@@ -174,4 +174,8 @@ interface ILAVFSettings : public IUnknown
 
   // Get whether Matroska Linked Segments should be loaded from other files
   STDMETHOD_(BOOL,GetLoadMatroskaExternalSegments)() = 0;
+
+  // Get the list of available formats
+  // Memory for the string array will be allocated, and has to be free'ed by the caller with CoTaskMemFree
+  STDMETHOD(GetFormats)(LPSTR** formats, UINT* nFormats) = 0;
 };

--- a/demuxer/LAVSplitter/LAVSplitter.cpp
+++ b/demuxer/LAVSplitter/LAVSplitter.cpp
@@ -1761,6 +1761,39 @@ STDMETHODIMP_(BOOL) CLAVSplitter::GetLoadMatroskaExternalSegments()
   return m_settings.MatroskaExternalSegments;
 }
 
+STDMETHODIMP CLAVSplitter::GetFormats(LPSTR** formats, UINT* nFormats)
+{
+  CheckPointer(formats, E_POINTER);
+  CheckPointer(nFormats, E_POINTER);
+
+  *nFormats = (UINT)m_InputFormats.size();
+
+  *formats = (LPSTR*)CoTaskMemAlloc(sizeof(LPSTR) * *nFormats);
+  CheckPointer(*formats, E_OUTOFMEMORY);
+
+  size_t i = 0;
+  for (auto it = m_InputFormats.begin(); it != m_InputFormats.end(); it++, i++) {
+    size_t len = strlen(it->strName) + 1;
+    *formats[i] = (LPSTR)CoTaskMemAlloc(sizeof(CHAR) * len);
+    if (!*formats[i]) {
+      break;
+    }
+    strcpy_s(*formats[i], len, it->strName);
+  }
+
+  if (i != *nFormats) {
+    for (size_t j = 0; j < i; j++) {
+      CoTaskMemFree(*formats[i]);
+    }
+    CoTaskMemFree(*formats);
+    *formats = NULL;
+
+    return E_OUTOFMEMORY;
+  }
+
+  return S_OK;
+}
+
 STDMETHODIMP_(std::set<FormatInfo>&) CLAVSplitter::GetInputFormats()
 {
   return m_InputFormats;

--- a/demuxer/LAVSplitter/LAVSplitter.h
+++ b/demuxer/LAVSplitter/LAVSplitter.h
@@ -170,6 +170,7 @@ public:
   STDMETHODIMP_(BOOL) GetPreferHighQualityAudioStreams();
   STDMETHODIMP SetLoadMatroskaExternalSegments(BOOL bEnabled);
   STDMETHODIMP_(BOOL) GetLoadMatroskaExternalSegments();
+  STDMETHODIMP GetFormats(LPSTR** formats, UINT* nFormats);
 
   // ILAVSplitterSettingsInternal
   STDMETHODIMP_(LPCSTR) GetInputFormat() { if (m_pDemuxer) return m_pDemuxer->GetContainerFormat(); return NULL; }


### PR DESCRIPTION
This would be needed to play nice with MPC-HC's evil plans. I'm open to suggestions if that's not acceptable as is.
