### PR TITLE
Control DLL loading to avoid sharing the ffmpeg/libbluray DLLs

### DIFF
--- a/decoder/LAVAudio/LAVAudio.manifest
+++ b/decoder/LAVAudio/LAVAudio.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="LAVFilters.Dependencies" version="1.0.0.0" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/decoder/LAVAudio/LAVAudio.vcxproj
+++ b/decoder/LAVAudio/LAVAudio.vcxproj
@@ -73,6 +73,9 @@
       <AdditionalDependencies>advapi32.lib;ole32.lib;winmm.lib;user32.lib;oleaut32.lib;shell32.lib;Shlwapi.lib;Comctl32.lib;strmbasd.lib;dsutild.lib;avformat-lav.lib;avutil-lav.lib;avcodec-lav.lib;avresample-lav.lib</AdditionalDependencies>
       <ModuleDefinitionFile>LAVAudio.def</ModuleDefinitionFile>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)\$(ProjectName).manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -91,6 +94,9 @@
       <Outputs>$(OutDir)..\$(TargetFileName)</Outputs>
       <Inputs>$(TargetDir)\$(TargetName)$(TargetExt)</Inputs>
     </CustomBuildStep>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)\$(ProjectName).manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Bitstream.cpp" />
@@ -128,6 +134,14 @@
   <ItemGroup>
     <None Include="..\..\resources\blue.ico" />
     <None Include="LAVAudio.rc2" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\resources\LAVFilters.Dependencies.manifest">
+      <Command>copy %(FullPath) $(IntermediateOutputPath)..</Command>
+      <Message>Copying Manifest file</Message>
+      <Outputs>$(IntermediateOutputPath)..\%(Filename)%(Extension);%(Outputs)</Outputs>
+    </CustomBuild>
+    <Manifest Include="LAVAudio.manifest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/decoder/LAVAudio/LAVAudio.vcxproj.filters
+++ b/decoder/LAVAudio/LAVAudio.vcxproj.filters
@@ -97,4 +97,14 @@
       <Filter>Resource Files</Filter>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="LAVAudio.manifest">
+      <Filter>Resource Files</Filter>
+    </Manifest>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\resources\LAVFilters.Dependencies.manifest">
+      <Filter>Resource Files</Filter>
+    </CustomBuild>
+  </ItemGroup>
 </Project>

--- a/decoder/LAVVideo/LAVVideo.manifest
+++ b/decoder/LAVVideo/LAVVideo.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="LAVFilters.Dependencies" version="1.0.0.0" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/decoder/LAVVideo/LAVVideo.vcxproj
+++ b/decoder/LAVVideo/LAVVideo.vcxproj
@@ -74,6 +74,9 @@
       <AdditionalDependencies>advapi32.lib;ole32.lib;gdi32.lib;winmm.lib;user32.lib;oleaut32.lib;shell32.lib;Shlwapi.lib;Comctl32.lib;d3d9.lib;dmoguids.lib;strmbasd.lib;dsutild.lib;avutil-lav.lib;avcodec-lav.lib;swscale-lav.lib;avfilter-lav.lib</AdditionalDependencies>
       <ModuleDefinitionFile>LAVVideo.def</ModuleDefinitionFile>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)\$(ProjectName).manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -93,6 +96,9 @@
       <Outputs>$(OutDir)..\$(TargetFileName)</Outputs>
       <Inputs>$(TargetDir)\$(TargetName)$(TargetExt)</Inputs>
     </CustomBuildStep>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)\$(ProjectName).manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="decoders\avcodec.cpp" />
@@ -173,6 +179,16 @@
   <ItemGroup>
     <None Include="..\..\resources\red.ico" />
     <None Include="LAVVideo.rc2" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\resources\LAVFilters.Dependencies.manifest">
+      <Command>copy %(FullPath) $(IntermediateOutputPath)..</Command>
+      <Message>Copying Manifest file</Message>
+      <Outputs>$(IntermediateOutputPath)..\%(Filename)%(Extension);%(Outputs)</Outputs>
+    </CustomBuild>
+    <Manifest Include="LAVVideo.manifest">
+      <SubType>Designer</SubType>
+    </Manifest>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/decoder/LAVVideo/LAVVideo.vcxproj.filters
+++ b/decoder/LAVVideo/LAVVideo.vcxproj.filters
@@ -265,4 +265,14 @@
       <Filter>Resource Files</Filter>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="LAVVideo.manifest">
+      <Filter>Resource Files</Filter>
+    </Manifest>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\resources\LAVFilters.Dependencies.manifest">
+      <Filter>Resource Files</Filter>
+    </CustomBuild>
+  </ItemGroup>
 </Project>

--- a/demuxer/LAVSplitter/LAVSplitter.manifest
+++ b/demuxer/LAVSplitter/LAVSplitter.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="LAVFilters.Dependencies" version="1.0.0.0" />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/demuxer/LAVSplitter/LAVSplitter.vcxproj
+++ b/demuxer/LAVSplitter/LAVSplitter.vcxproj
@@ -74,6 +74,9 @@
       <AdditionalDependencies>advapi32.lib;ole32.lib;winmm.lib;user32.lib;oleaut32.lib;Comctl32.lib;shell32.lib;version.lib;Shlwapi.lib;strmbasd.lib;dsutild.lib;demuxersd.lib;avformat-lav.lib;avutil-lav.lib;avcodec-lav.lib</AdditionalDependencies>
       <ModuleDefinitionFile>LAVSplitter.def</ModuleDefinitionFile>
     </Link>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)\$(ProjectName).manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -93,6 +96,9 @@
       <Outputs>$(OutDir)..\$(TargetFileName)</Outputs>
       <Inputs>$(TargetDir)\$(TargetName)$(TargetExt)</Inputs>
     </CustomBuildStep>
+    <Manifest>
+      <AdditionalManifestFiles>$(ProjectDir)\$(ProjectName).manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
@@ -138,6 +144,14 @@
   <ItemGroup>
     <None Include="..\..\resources\white.ico" />
     <None Include="LAVSplitter.rc2" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\resources\LAVFilters.Dependencies.manifest">
+      <Command>copy %(FullPath) $(IntermediateOutputPath)..</Command>
+      <Message>Copying Manifest file</Message>
+      <Outputs>$(IntermediateOutputPath)..\%(Filename)%(Extension);%(Outputs)</Outputs>
+    </CustomBuild>
+    <None Include="LAVSplitter.manifest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/demuxer/LAVSplitter/LAVSplitter.vcxproj.filters
+++ b/demuxer/LAVSplitter/LAVSplitter.vcxproj.filters
@@ -129,5 +129,13 @@
     <None Include="..\..\resources\white.ico">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="LAVSplitter.manifest">
+      <Filter>Resource Files</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\resources\LAVFilters.Dependencies.manifest">
+      <Filter>Resource Files</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>

--- a/resources/LAVFilters.Dependencies.manifest
+++ b/resources/LAVFilters.Dependencies.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type='win32' name='LAVFilters.Dependencies' version='1.0.0.0' />
+  <file name="avutil-lav-52.dll" />
+  <file name="avcodec-lav-55.dll" />
+  <file name="avformat-lav-55.dll" />
+  <file name="avresample-lav-1.dll" />
+  <file name="avfilter-lav-3.dll" />
+  <file name="swscale-lav-2.dll" />
+  <file name="libbluray.dll" />
+</assembly>


### PR DESCRIPTION
This is a first attempt to make using different version of LAVFilters at the same time relatively safe. I used the manifest approach proposed by Lord from CCCP but I'm opened to discussion.
