### PR TITLE
LAV Splitter: Exhibits MKV attachments through IDSMResourceBag interface.

### DIFF
--- a/common/DSUtilLite/DSMResourceBag.cpp
+++ b/common/DSUtilLite/DSMResourceBag.cpp
@@ -1,0 +1,191 @@
+/*
+ * (C) 2003-2006 Gabest
+ * (C) 2006-2013 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "stdafx.h"
+#include "DSMResourceBag.h"
+
+
+//
+// CDSMResource
+//
+
+CCritSec CDSMResource::m_csResources;
+std::map<uintptr_t, CDSMResource*> CDSMResource::m_resources;
+
+CDSMResource::CDSMResource()
+    : mime(L"application/octet-stream")
+    , tag(0)
+{
+    CAutoLock cAutoLock(&m_csResources);
+    m_resources[reinterpret_cast<uintptr_t>(this)] = this;
+}
+
+CDSMResource::CDSMResource(const CDSMResource& r)
+{
+    *this = r;
+
+    CAutoLock cAutoLock(&m_csResources);
+    m_resources[reinterpret_cast<uintptr_t>(this)] = this;
+}
+
+CDSMResource::CDSMResource(LPCWSTR name, LPCWSTR desc, LPCWSTR mime, BYTE* pData, int len, DWORD_PTR tag)
+{
+    this->name = name;
+    this->desc = desc;
+    this->mime = mime;
+    data.resize(len);
+    memcpy(data.data(), pData, data.size());
+    this->tag = tag;
+
+    CAutoLock cAutoLock(&m_csResources);
+    m_resources[reinterpret_cast<uintptr_t>(this)] = this;
+}
+
+CDSMResource::~CDSMResource()
+{
+    CAutoLock cAutoLock(&m_csResources);
+    m_resources.erase(reinterpret_cast<uintptr_t>(this));
+}
+
+CDSMResource& CDSMResource::operator=(const CDSMResource& r)
+{
+    if (this != &r) {
+        tag = r.tag;
+        name = r.name;
+        desc = r.desc;
+        mime = r.mime;
+        data = r.data;
+    }
+    return *this;
+}
+
+//
+// IDSMResourceBagImpl
+//
+
+IDSMResourceBagImpl::IDSMResourceBagImpl()
+{
+}
+
+// IDSMResourceBag
+
+STDMETHODIMP_(DWORD) IDSMResourceBagImpl::ResGetCount()
+{
+    return (DWORD)m_resources.size();
+}
+
+STDMETHODIMP IDSMResourceBagImpl::ResGet(DWORD iIndex, BSTR* ppName, BSTR* ppDesc, BSTR* ppMime, BYTE** ppData, DWORD* pDataLen, DWORD_PTR* pTag)
+{
+    if (ppData) {
+        CheckPointer(pDataLen, E_POINTER);
+    }
+
+    if (iIndex >= (DWORD)m_resources.size()) {
+        return E_INVALIDARG;
+    }
+
+    CDSMResource& r = m_resources[iIndex];
+
+    if (ppName) {
+        *ppName = SysAllocString(r.name.data());
+        if (*ppName == NULL)
+            return E_OUTOFMEMORY;
+    }
+    if (ppDesc) {
+        *ppDesc = SysAllocString(r.desc.data());
+        if (*ppDesc == NULL)
+            return E_OUTOFMEMORY;
+    }
+    if (ppMime) {
+        *ppMime = SysAllocString(r.mime.data());
+        if (*ppMime == NULL)
+            return E_OUTOFMEMORY;
+    }
+    if (ppData) {
+        *pDataLen = (DWORD)r.data.size();
+        memcpy(*ppData = (BYTE*)CoTaskMemAlloc(*pDataLen), r.data.data(), *pDataLen);
+    }
+    if (pTag) {
+        *pTag = r.tag;
+    }
+
+    return S_OK;
+}
+
+STDMETHODIMP IDSMResourceBagImpl::ResSet(DWORD iIndex, LPCWSTR pName, LPCWSTR pDesc, LPCWSTR pMime, const BYTE* pData, DWORD len, DWORD_PTR tag)
+{
+    if (iIndex >= (DWORD)m_resources.size()) {
+        return E_INVALIDARG;
+    }
+
+    CDSMResource& r = m_resources[iIndex];
+
+    if (pName) {
+        r.name = pName;
+    }
+    if (pDesc) {
+        r.desc = pDesc;
+    }
+    if (pMime) {
+        r.mime = pMime;
+    }
+    if (pData || len == 0) {
+        r.data.resize(len);
+        if (pData) {
+            memcpy(r.data.data(), pData, r.data.size());
+        }
+    }
+    r.tag = tag;
+
+    return S_OK;
+}
+
+STDMETHODIMP IDSMResourceBagImpl::ResAppend(LPCWSTR pName, LPCWSTR pDesc, LPCWSTR pMime, BYTE* pData, DWORD len, DWORD_PTR tag)
+{
+    m_resources.push_back(CDSMResource());
+    return ResSet((DWORD)m_resources.size() - 1, pName, pDesc, pMime, pData, len, tag);
+}
+
+STDMETHODIMP IDSMResourceBagImpl::ResRemoveAt(DWORD iIndex)
+{
+    if (iIndex >= (DWORD)m_resources.size()) {
+        return E_INVALIDARG;
+    }
+
+    m_resources.erase(m_resources.cbegin() + iIndex);
+
+    return S_OK;
+}
+
+STDMETHODIMP IDSMResourceBagImpl::ResRemoveAll(DWORD_PTR tag)
+{
+    if (tag) {
+        for (auto crit = m_resources.cend() - 1; crit >= m_resources.begin(); --crit) {
+            if (crit->tag == tag) {
+                m_resources.erase(crit);
+            }
+        }
+    } else {
+        m_resources.clear();
+    }
+
+    return S_OK;
+}

--- a/common/DSUtilLite/DSMResourceBag.h
+++ b/common/DSUtilLite/DSMResourceBag.h
@@ -1,0 +1,79 @@
+/*
+ * (C) 2003-2006 Gabest
+ * (C) 2006-2013 see Authors.txt
+ *
+ * This file is part of MPC-HC.
+ *
+ * MPC-HC is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MPC-HC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+
+// IDSMResourceBag
+
+interface __declspec(uuid("EBAFBCBE-BDE0-489A-9789-05D5692E3A93"))
+IDSMResourceBag :
+public IUnknown {
+    STDMETHOD_(DWORD, ResGetCount)() PURE;
+    STDMETHOD(ResGet)(DWORD iIndex, BSTR * ppName, BSTR * ppDesc, BSTR * ppMime, BYTE** ppData, DWORD * pDataLen, DWORD_PTR * pTag) PURE;
+    STDMETHOD(ResSet)(DWORD iIndex, LPCWSTR pName, LPCWSTR pDesc, LPCWSTR pMime, const BYTE * pData, DWORD len, DWORD_PTR tag) PURE;
+    STDMETHOD(ResAppend)(LPCWSTR pName, LPCWSTR pDesc, LPCWSTR pMime, BYTE * pData, DWORD len, DWORD_PTR tag) PURE;
+    STDMETHOD(ResRemoveAt)(DWORD iIndex) PURE;
+    STDMETHOD(ResRemoveAll)(DWORD_PTR tag) PURE;
+};
+
+class CDSMResource
+{
+public:
+    DWORD_PTR tag;
+    std::wstring name, desc, mime;
+    std::vector<BYTE> data;
+    CDSMResource();
+    CDSMResource(const CDSMResource& r);
+    CDSMResource(LPCWSTR name, LPCWSTR desc, LPCWSTR mime, BYTE* pData, int len, DWORD_PTR tag = 0);
+    virtual ~CDSMResource();
+    CDSMResource& operator=(const CDSMResource& r);
+
+    // global access to all resources
+    static CCritSec m_csResources;
+    static std::map<uintptr_t, CDSMResource*> m_resources;
+};
+
+class IDSMResourceBagImpl : public IDSMResourceBag
+{
+protected:
+    std::vector<CDSMResource> m_resources;
+
+public:
+    IDSMResourceBagImpl();
+
+    void operator+=(const CDSMResource& r) { m_resources.push_back(r); }
+
+    // IDSMResourceBag
+
+    STDMETHODIMP_(DWORD) ResGetCount();
+    STDMETHODIMP ResGet(DWORD iIndex, BSTR* ppName, BSTR* ppDesc, BSTR* ppMime,
+                        BYTE** ppData, DWORD* pDataLen, DWORD_PTR* pTag = nullptr);
+    STDMETHODIMP ResSet(DWORD iIndex, LPCWSTR pName, LPCWSTR pDesc, LPCWSTR pMime,
+                        const BYTE* pData, DWORD len, DWORD_PTR tag = 0);
+    STDMETHODIMP ResAppend(LPCWSTR pName, LPCWSTR pDesc, LPCWSTR pMime,
+                           BYTE* pData, DWORD len, DWORD_PTR tag = 0);
+    STDMETHODIMP ResRemoveAt(DWORD iIndex);
+    STDMETHODIMP ResRemoveAll(DWORD_PTR tag = 0);
+};

--- a/common/DSUtilLite/DSUtilLite.vcxproj
+++ b/common/DSUtilLite/DSUtilLite.vcxproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <ClInclude Include="BaseDSPropPage.h" />
     <ClInclude Include="CueSheet.h" />
+    <ClInclude Include="DSMResourceBag.h" />
     <ClInclude Include="PopupMenu.h" />
     <ClInclude Include="BaseTrayIcon.h" />
     <ClInclude Include="ByteParser.h" />
@@ -99,6 +100,7 @@
   <ItemGroup>
     <ClCompile Include="BaseDSPropPage.cpp" />
     <ClCompile Include="CueSheet.cpp" />
+    <ClCompile Include="DSMResourceBag.cpp" />
     <ClCompile Include="PopupMenu.cpp" />
     <ClCompile Include="BaseTrayIcon.cpp" />
     <ClCompile Include="ByteParser.cpp" />

--- a/common/DSUtilLite/DSUtilLite.vcxproj.filters
+++ b/common/DSUtilLite/DSUtilLite.vcxproj.filters
@@ -78,6 +78,9 @@
     <ClInclude Include="CueSheet.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DSMResourceBag.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="timer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -126,6 +129,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="CueSheet.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DSMResourceBag.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/demuxer/Demuxers/LAVFDemuxer.h
+++ b/demuxer/Demuxers/LAVFDemuxer.h
@@ -27,6 +27,7 @@
 #include "BaseDemuxer.h"
 #include "IKeyFrameInfo.h"
 #include "ITrackInfo.h"
+#include "DSMResourceBag.h"
 #include "FontInstaller.h"
 
 #define SUBMODE_FORCED_PGS_ONLY 0xFF
@@ -35,7 +36,8 @@ class FormatInfo;
 class CBDDemuxer;
 
 #define FFMPEG_FILE_BUFFER_SIZE   32768 // default reading size for ffmpeg
-class CLAVFDemuxer : public CBaseDemuxer, public IAMExtendedSeeking, public IKeyFrameInfo, public ITrackInfo, public IAMMediaContent, public IPropertyBag
+class CLAVFDemuxer : public CBaseDemuxer, public IAMExtendedSeeking, public IKeyFrameInfo, public ITrackInfo, public IAMMediaContent, public IPropertyBag,
+                     public IDSMResourceBagImpl
 {
 public:
   CLAVFDemuxer(CCritSec *pLock, ILAVFSettingsInternal *settings);

--- a/demuxer/LAVSplitter/LAVSplitter.cpp
+++ b/demuxer/LAVSplitter/LAVSplitter.cpp
@@ -297,7 +297,8 @@ STDMETHODIMP CLAVSplitter::NonDelegatingQueryInterface(REFIID riid, void** ppv)
 
   *ppv = nullptr;
 
-  if (m_pDemuxer && (riid == __uuidof(IKeyFrameInfo) || riid == __uuidof(ITrackInfo) || riid == IID_IAMExtendedSeeking || riid == IID_IAMMediaContent || riid == IID_IPropertyBag)) {
+  if (m_pDemuxer
+        && (riid == __uuidof(IKeyFrameInfo) || riid == __uuidof(ITrackInfo) || riid == IID_IAMExtendedSeeking || riid == IID_IAMMediaContent || riid == IID_IPropertyBag || riid == __uuidof(IDSMResourceBag)) {
     return m_pDemuxer->QueryInterface(riid, ppv);
   }
 


### PR DESCRIPTION
This commit enables seeing and saving MKV attachments in MPC-HC using Gabest interface.

I'm not sure you will be interested but I think it's better to propose that for upstream integration just in case.