### PR TITLE
LAV Audio: Fix a deadlock when changing bitstreaming settings when paused

### DIFF
--- a/decoder/LAVAudio/LAVAudio.cpp
+++ b/decoder/LAVAudio/LAVAudio.cpp
@@ -87,6 +87,7 @@ CLAVAudio::CLAVAudio(LPUNKNOWN pUnk, HRESULT* phr)
   , m_DecodeLayoutSanified(0)
   , m_bChannelMappingRequired(FALSE)
   , m_bFindDTSInPCM(FALSE)
+  , m_bBitStreamingSettingsChanged(FALSE)
   , m_FallbackFormat(SampleFormat_None)
   , m_dwOverrideMixer(0)
   , m_bNeedSyncpoint(FALSE)
@@ -577,7 +578,7 @@ HRESULT CLAVAudio::SetBitstreamConfig(LAVBitstreamCodec bsCodec, BOOL bEnabled)
 
   SaveSettings();
 
-  UpdateBitstreamContext();
+  m_bBitStreamingSettingsChanged = TRUE;
 
   return S_OK;
 }
@@ -593,7 +594,7 @@ STDMETHODIMP CLAVAudio::SetDTSHDFraming(BOOL bHDFraming)
   SaveSettings();
 
   if (m_nCodecId == AV_CODEC_ID_DTS)
-    UpdateBitstreamContext();
+    m_bBitStreamingSettingsChanged = TRUE;
 
   return S_OK;
 }
@@ -1564,6 +1565,11 @@ HRESULT CLAVAudio::Receive(IMediaSample *pIn)
     m_buff.Clear();
 
     m_bQueueResync = TRUE;
+  }
+
+  if (m_bBitStreamingSettingsChanged) {
+    m_bBitStreamingSettingsChanged = FALSE;
+    UpdateBitstreamContext();
   }
 
   if (!m_pAVCtx) {

--- a/decoder/LAVAudio/LAVAudio.h
+++ b/decoder/LAVAudio/LAVAudio.h
@@ -315,6 +315,7 @@ private:
   BOOL                m_bForceDTSCore;
   CBitstreamParser    m_bsParser;
   BOOL                m_bFindDTSInPCM;
+  BOOL                m_bBitStreamingSettingsChanged;
 
   FloatingAverage<REFERENCE_TIME> m_faJitter;
   REFERENCE_TIME      m_JitterLimit;


### PR DESCRIPTION
If one changes LAV Audio's bitstreaming settings when playblack is paused, LAV will freeze because it tries to lock on the `m_csReceive` critical section which is already locked in `Receive`.

With this small patch, the application of the settings is delayed to the next call to `Receive` which avoids the problem.

I can't really test that patch since I don't have the hardware for it but at least it seems to work for what I can test without having anything plugged on the S/PDIF output. I don't know LAV's code base very well so I hope that patch is acceptable.
