### PR TITLE
DVD subtitles

### DIFF
--- a/decoder/LAVVideo/subtitles/LAVSubtitleProvider.cpp
+++ b/decoder/LAVVideo/subtitles/LAVSubtitleProvider.cpp
@@ -113,17 +113,24 @@ STDMETHODIMP CLAVSubtitleProvider::RequestFrame(REFERENCE_TIME start, REFERENCE_
   // Scope this so we limit the provider-lock to the part where its needed
   {
     CAutoLock lock(this);
+    CLAVSubRect *pRectToRender = nullptr;
     for (auto it = m_SubFrames.begin(); it != m_SubFrames.end(); it++) {
       CLAVSubRect *pRect = *it;
       if ((pRect->rtStart == AV_NOPTS_VALUE || pRect->rtStart <= mid)
         && (pRect->rtStop == AV_NOPTS_VALUE || pRect->rtStop > mid)
         && (m_bComposit || pRect->forced)) {
+        pRectToRender = *it;
 
-        if (m_pHLI && PTS2RT(m_pHLI->StartPTM) <= mid && PTS2RT(m_pHLI->EndPTM) >= mid) {
-          pRect = ProcessDVDHLI(pRect);
-        }
-        subtitleFrame->AddBitmap(pRect);
+        if (pRect->rtStop != AV_NOPTS_VALUE)
+          break;
       }
+    }
+
+    if (pRectToRender) {
+      if (m_pHLI && PTS2RT(m_pHLI->StartPTM) <= mid && PTS2RT(m_pHLI->EndPTM) >= mid) {
+        pRectToRender = ProcessDVDHLI(pRectToRender);
+      }
+      subtitleFrame->AddBitmap(pRectToRender);
     }
   }
 


### PR DESCRIPTION
Those commits are the result of some testings done to understand MPC-HC tickets reporting strange behavior with DVD subtitles.

I've kept the first one (https://github.com/Underground78/lavfilters/commit/4b7628c329eccc9453215f4d146c4eef71e61270) even though it's overridden by the second commit because it's the only one that seems like a real bug. Some parenthesis got lost and changed the meaning of the test to decide whether rendering a sub or not.

The two others are attempts to improve the behavior when the timings are unknown:
- https://github.com/Underground78/lavfilters/commit/ad351d9ddf408a58ed32a59668cfc1b913835188 ensures that the end time is checked so that 38ff1fe16afc20aa7f774fed2c1691bfa4f2b5c2 has more effect. It also ensures that the fading support is disabled when the timings are unknown since it confuses the renderer even more by introducing subtitles with completely funky timings.
- https://github.com/Underground78/lavfilters/commit/18923a585c1a25d3f71eb5a4ad4da4d7797b3ade completely prevents rendering more than one subtitle at a time. It tries to render the more recent one unless a known end time that matches is found.
