### PR TITLE
Fix a performance issue when converting NV12 to NV12.

### DIFF
--- a/decoder/LAVVideo/LAVPixFmtConverter.h
+++ b/decoder/LAVVideo/LAVPixFmtConverter.h
@@ -114,6 +114,7 @@ private:
   // Pixel Implementations
   DECLARE_CONV_FUNC(convert_generic);
   DECLARE_CONV_FUNC(plane_copy);
+  DECLARE_CONV_FUNC(plane_copy_sse2);
   DECLARE_CONV_FUNC(convert_yuv444_ayuv);
   DECLARE_CONV_FUNC(convert_yuv444_ayuv_dither_le);
   DECLARE_CONV_FUNC(convert_yuv444_y410);


### PR DESCRIPTION
An user reported some performance issues when using software decoding (https://trac.mpc-hc.org/ticket/4357). Partially reverting 51a51dec52d9b89246878f47187d5dcaedb64b83 seems to fix the issue.

Note that this is mostly a bug report, not that much a real PR.
