### PR TITLE
Fix a crash with DVD subtitles on x64 builds with software decoding.

### DIFF
--- a/decoder/LAVVideo/subtitles/LAVSubtitleConsumer.cpp
+++ b/decoder/LAVVideo/subtitles/LAVSubtitleConsumer.cpp
@@ -106,7 +106,7 @@ STDMETHODIMP CLAVSubtitleConsumer::ProcessFrame(LAVFrame *pFrame)
     }
 
     BYTE *data[4] = {0};
-    int stride[4] = {0};
+    ptrdiff_t stride[4] = {0};
     LAVPixelFormat format = pFrame->format;
     int bpp = pFrame->bpp;
 
@@ -286,7 +286,7 @@ STDMETHODIMP CLAVSubtitleConsumer::SelectBlendFunction()
   return S_OK;
 }
 
-STDMETHODIMP CLAVSubtitleConsumer::ProcessSubtitleBitmap(LAVPixelFormat pixFmt, int bpp, RECT videoRect, BYTE *videoData[4], int videoStride[4], RECT subRect, POINT subPosition, SIZE subSize, const uint8_t *rgbData, int pitch)
+STDMETHODIMP CLAVSubtitleConsumer::ProcessSubtitleBitmap(LAVPixelFormat pixFmt, int bpp, RECT videoRect, BYTE *videoData[4], ptrdiff_t videoStride[4], RECT subRect, POINT subPosition, SIZE subSize, const uint8_t *rgbData, int pitch)
 {
   if (subRect.left != 0 || subRect.top != 0) {
     DbgLog((LOG_ERROR, 10, L"ProcessSubtitleBitmap(): Left/Top in SubRect non-zero"));

--- a/decoder/LAVVideo/subtitles/LAVSubtitleConsumer.h
+++ b/decoder/LAVVideo/subtitles/LAVSubtitleConsumer.h
@@ -24,7 +24,7 @@
 
 #include "../decoders/ILAVDecoder.h"
 
-#define BLEND_FUNC_PARAMS (BYTE* video[4], int videoStride[4], RECT vidRect, BYTE* subData[4], int subStride[4], POINT position, SIZE size, LAVPixelFormat pixFmt, int bpp)
+#define BLEND_FUNC_PARAMS (BYTE* video[4], ptrdiff_t videoStride[4], RECT vidRect, BYTE* subData[4], int subStride[4], POINT position, SIZE size, LAVPixelFormat pixFmt, int bpp)
 
 #define DECLARE_BLEND_FUNC(name) \
   HRESULT name BLEND_FUNC_PARAMS
@@ -68,7 +68,7 @@ public:
   void SetVideoSize(LONG w, LONG h) { context.originalVideoSize.cx = w; context.originalVideoSize.cy = h; }
 
 private:
-  STDMETHODIMP ProcessSubtitleBitmap(LAVPixelFormat pixFmt, int bpp, RECT videoRect, BYTE *videoData[4], int videoStride[4], RECT subRect, POINT subPosition, SIZE subSize, const uint8_t *rgbData, int pitch);
+  STDMETHODIMP ProcessSubtitleBitmap(LAVPixelFormat pixFmt, int bpp, RECT videoRect, BYTE *videoData[4], ptrdiff_t videoStride[4], RECT subRect, POINT subPosition, SIZE subSize, const uint8_t *rgbData, int pitch);
 
   STDMETHODIMP SelectBlendFunction();
   typedef HRESULT (CLAVSubtitleConsumer::*BlendFn) BLEND_FUNC_PARAMS;

--- a/decoder/LAVVideo/subtitles/blend/blend_generic.cpp
+++ b/decoder/LAVVideo/subtitles/blend/blend_generic.cpp
@@ -29,7 +29,7 @@ DECLARE_BLEND_FUNC_IMPL(blend_rgb_c)
   BYTE *rgbOut = video[0];
   const BYTE *subIn = subData[0];
 
-  const int outStride = videoStride[0];
+  const ptrdiff_t outStride = videoStride[0];
   const int inStride = subStride[0];
 
   const int dstep = (pixFmt == LAVPixFmt_RGB24) ? 3 : 4;
@@ -75,8 +75,8 @@ DECLARE_BLEND_FUNC_IMPL(blend_yuv_c)
   const BYTE *subV = subData[2];
   const BYTE *subA = subData[3];
 
-  const int outStride = videoStride[0];
-  const int outStrideUV = videoStride[1];
+  const ptrdiff_t outStride = videoStride[0];
+  const ptrdiff_t outStrideUV = videoStride[1];
   const int inStride = subStride[0];
   const int inStrideUV = subStride[1];
 


### PR DESCRIPTION
Some code was forgotten in 0c8c08104c3e0d92529a01701260254704740241.
