### PR TITLE
Add support for RTMP protocol with librtmp parameters input style.

### DIFF
--- a/build_ffmpeg.sh
+++ b/build_ffmpeg.sh
@@ -71,6 +71,8 @@ configure() (
     --enable-protocol=rtp           \
     --enable-protocol=http          \
     --enable-protocol=crypto        \
+    --enable-protocol=rtmp          \
+    --enable-protocol=rtmpt         \
     --disable-muxers                \
     --enable-muxer=spdif            \
     --disable-hwaccels              \

--- a/build_ffmpeg_msvc.sh
+++ b/build_ffmpeg_msvc.sh
@@ -58,6 +58,8 @@ configure() (
     --enable-protocol=rtp           \
     --enable-protocol=http          \
     --enable-protocol=crypto        \
+    --enable-protocol=rtmp          \
+    --enable-protocol=rtmpt         \
     --disable-muxers                \
     --enable-muxer=spdif            \
     --disable-hwaccels              \


### PR DESCRIPTION
Hi, 

I've enabled ffmpeg's rtmp support and added parser for librtmp style input. Main goal is to support various applications that pass parameters this way like livestreamer.

There is also related patch in ffmpeg to better support certain cases. This is not a blocker, but would be nice to have this PR merged along with ffmpeg update in LAV. https://github.com/FFmpeg/FFmpeg/commit/f22cf88fd3172d4527c58e58af8f0667485ae6d6

Regards :)
