### PR TITLE
Do not round aspect ratio when one of its values exceed 255.

### DIFF
--- a/decoder/LAVVideo/decoders/avcodec.cpp
+++ b/decoder/LAVVideo/decoders/avcodec.cpp
@@ -853,7 +853,7 @@ STDMETHODIMP CDecAvcodec::Decode(const BYTE *buffer, int buflen, REFERENCE_TIME 
     AVRational display_aspect_ratio;
     int64_t num = (int64_t)m_pFrame->sample_aspect_ratio.num * m_pFrame->width;
     int64_t den = (int64_t)m_pFrame->sample_aspect_ratio.den * m_pFrame->height;
-    av_reduce(&display_aspect_ratio.num, &display_aspect_ratio.den, num, den, 1 << 30);
+    av_reduce(&display_aspect_ratio.num, &display_aspect_ratio.den, num, den, INT_MAX);
 
     pOutFrame->width        = m_pFrame->width;
     pOutFrame->height       = m_pFrame->height;

--- a/decoder/LAVVideo/decoders/wmv9.cpp
+++ b/decoder/LAVVideo/decoders/wmv9.cpp
@@ -493,7 +493,7 @@ STDMETHODIMP CDecWMV9::ProcessOutput()
   AVRational display_aspect_ratio;
   int64_t num = (int64_t)m_StreamAR.num * pBMI->biWidth;
   int64_t den = (int64_t)m_StreamAR.den * pBMI->biHeight;
-  av_reduce(&display_aspect_ratio.num, &display_aspect_ratio.den, num, den, 1 << 30);
+  av_reduce(&display_aspect_ratio.num, &display_aspect_ratio.den, num, den, INT_MAX);
 
   BYTE contentType = 0;
   DWORD dwPropSize = 1;

--- a/decoder/LAVVideo/decoders/wmv9mft.cpp
+++ b/decoder/LAVVideo/decoders/wmv9mft.cpp
@@ -496,7 +496,7 @@ STDMETHODIMP CDecWMV9MFT::ProcessOutput()
   MFGetAttributeRatio(pMTOut, MF_MT_PIXEL_ASPECT_RATIO, (UINT32*)&pixel_aspect_ratio.num, (UINT32*)&pixel_aspect_ratio.den);
 
   AVRational display_aspect_ratio = {0, 0};
-  av_reduce(&display_aspect_ratio.num, &display_aspect_ratio.den, (int64_t)pixel_aspect_ratio.num * pFrame->width, (int64_t)pixel_aspect_ratio.den * pFrame->height, 1 << 30);
+  av_reduce(&display_aspect_ratio.num, &display_aspect_ratio.den, (int64_t)pixel_aspect_ratio.num * pFrame->width, (int64_t)pixel_aspect_ratio.den * pFrame->height, INT_MAX);
 
   pFrame->interlaced = MFGetAttributeUINT32(OutputBuffer.pSample, MFSampleExtension_Interlaced,       FALSE);
   pFrame->repeat     = MFGetAttributeUINT32(OutputBuffer.pSample, MFSampleExtension_RepeatFirstField, FALSE);

--- a/decoder/LAVVideo/parsers/VC1HeaderParser.cpp
+++ b/decoder/LAVVideo/parsers/VC1HeaderParser.cpp
@@ -187,7 +187,7 @@ void CVC1HeaderParser::VC1ParseSequenceHeader(GetBitContext *gb)
         hdr.ar.num = w;
         hdr.ar.den = h;
       } else {
-        av_reduce(&hdr.ar.num, &hdr.ar.den, hdr.height * w, hdr.width * h, 1 << 30);
+        av_reduce(&hdr.ar.num, &hdr.ar.den, (int64_t)hdr.height * w, (int64_t)hdr.width * h, INT_MAX);
       }
     }
 

--- a/demuxer/Demuxers/LAVFDemuxer.cpp
+++ b/demuxer/Demuxers/LAVFDemuxer.cpp
@@ -889,7 +889,7 @@ STDMETHODIMP CLAVFDemuxer::CreatePacketMediaType(Packet *pPacket, enum AVCodecID
           }
           if (aspect_num && aspect_den) {
             int num = vih2->bmiHeader.biWidth, den = vih2->bmiHeader.biHeight;
-            av_reduce(&num, &den, (int64_t)aspect_num * num, (int64_t)aspect_den * den, 255);
+            av_reduce(&num, &den, (int64_t)aspect_num * num, (int64_t)aspect_den * den, INT_MAX);
             vih2->dwPictAspectRatioX = num;
             vih2->dwPictAspectRatioY = den;
           }

--- a/demuxer/Demuxers/LAVFVideoHelper.cpp
+++ b/demuxer/Demuxers/LAVFVideoHelper.cpp
@@ -270,9 +270,9 @@ VIDEOINFOHEADER2 *CLAVFVideoHelper::CreateVIH2(const AVStream* avstream, ULONG *
   AVRational rc = avstream->codec->sample_aspect_ratio;
   int num = vih->bmiHeader.biWidth, den = vih->bmiHeader.biHeight;
   if (r.den > 0 && r.num > 0) {
-    av_reduce(&num, &den, (int64_t)r.num * num, (int64_t)r.den * den, 255);
+    av_reduce(&num, &den, (int64_t)r.num * num, (int64_t)r.den * den, INT_MAX);
   } else if (rc.den > 0 && rc.num > 0) {
-    av_reduce(&num, &den, (int64_t)rc.num * num, (int64_t)rc.den * den, 255);
+    av_reduce(&num, &den, (int64_t)rc.num * num, (int64_t)rc.den * den, INT_MAX);
   } else {
     av_reduce(&num, &den, num, den, num);
   }


### PR DESCRIPTION
- Use the same limit everywhere for consistency.
- Add one missing cast to avoid possible overflow.

I have this guy whining that aspect ratio for his files is rounded... So here we are. What do you think about it?
