### PR TITLE
Detect TrueType Collection attachments as font files requiring installation

### DIFF
--- a/demuxer/Demuxers/LAVFDemuxer.cpp
+++ b/demuxer/Demuxers/LAVFDemuxer.cpp
@@ -592,7 +592,9 @@ STDMETHODIMP CLAVFDemuxer::InitAVFormat(LPCOLESTR pszFileName, BOOL bForce)
 
     UpdateSubStreams();
 
-    if (st->codec->codec_type == AVMEDIA_TYPE_ATTACHMENT && (st->codec->codec_id == AV_CODEC_ID_TTF || st->codec->codec_id == AV_CODEC_ID_OTF)) {
+    if (st->codec->codec_type == AVMEDIA_TYPE_ATTACHMENT
+        && (st->codec->codec_id == AV_CODEC_ID_TTF || st->codec->codec_id == AV_CODEC_ID_OTF
+            || (st->codec->extradata_size >= 4 && !strncmp((char*)st->codec->extradata, "ttcf", 4))) {
       if (!m_pFontInstaller) {
         m_pFontInstaller = new CFontInstaller();
       }


### PR DESCRIPTION
Until a few days ago, TrueType Collection attachments were not tagged with the appropriate mime type by mkvtoolnix. This causes LAV Splitter not to detect them as needing installation.

Do you think it's worth checking or should the users just remux their files?

PS: I couldn't remember of the alignment policy for the multi-line conditionals.