### PR TITLE
Fix typedef for some enums

### DIFF
--- a/common/includes/ITrackInfo.h
+++ b/common/includes/ITrackInfo.h
@@ -27,7 +27,7 @@ typedef enum TrackType {
 	TypeLogo     = 0x10,
 	TypeSubtitle = 0x11,
 	TypeControl  = 0x20
-};
+} TrackType;
 
 #pragma pack(push, 1)
 

--- a/decoder/LAVAudio/LAVAudioSettings.h
+++ b/decoder/LAVAudio/LAVAudioSettings.h
@@ -58,7 +58,7 @@ typedef enum LAVAudioCodec {
   Codec_ATRAC,
 
   Codec_AudioNB            // Number of entries (do not use when dynamically linking)
-};
+} LAVAudioCodec;
 
 // Bitstreaming Codecs supported in LAV Audio
 typedef enum LAVBitstreamCodec {
@@ -69,7 +69,7 @@ typedef enum LAVBitstreamCodec {
   Bitstream_DTSHD,
 
   Bitstream_NB        // Number of entries (do not use when dynamically linking)
-};
+} LAVBitstreamCodec;
 
 
 // Supported Sample Formats in LAV Audio
@@ -83,7 +83,7 @@ typedef enum LAVAudioSampleFormat {
   SampleFormat_Bitstream,
 
   SampleFormat_NB     // Number of entries (do not use when dynamically linking)
-};
+} LAVAudioSampleFormat;
 
 typedef enum LAVAudioMixingMode {
   MatrixEncoding_None,
@@ -91,7 +91,7 @@ typedef enum LAVAudioMixingMode {
   MatrixEncoding_DPLII,
 
   MatrixEncoding_NB
-};
+} LAVAudioMixingMode;
 
 // LAV Audio configuration interface
 [uuid("4158A22B-6553-45D0-8069-24716F8FF171")]

--- a/decoder/LAVVideo/LAVVideoSettings.h
+++ b/decoder/LAVVideo/LAVVideoSettings.h
@@ -89,7 +89,7 @@ typedef enum LAVVideoCodec {
   Codec_VP7,
 
   Codec_VideoNB            // Number of entries (do not use when dynamically linking)
-};
+} LAVVideoCodec;
 
 // Codecs with hardware acceleration
 typedef enum LAVVideoHWCodec {
@@ -101,7 +101,7 @@ typedef enum LAVVideoHWCodec {
   HWCodec_HEVC,
 
   HWCodec_NB    = HWCodec_HEVC + 1
-};
+} LAVVideoHWCodec;
 
 // Flags for HW Resolution support
 #define LAVHWResFlag_SD      0x0001
@@ -116,20 +116,20 @@ typedef enum LAVHWAccel {
   HWAccel_DXVA2,
   HWAccel_DXVA2CopyBack = HWAccel_DXVA2,
   HWAccel_DXVA2Native
-};
+} LAVHWAccel;
 
 // Deinterlace algorithms offered by the hardware decoders
 typedef enum LAVHWDeintModes {
   HWDeintMode_Weave,
   HWDeintMode_BOB, // Deprecated
   HWDeintMode_Hardware
-};
+} LAVHWDeintModes;
 
 // Software deinterlacing algorithms
 typedef enum LAVSWDeintModes {
   SWDeintMode_None,
   SWDeintMode_YADIF
-};
+} LAVSWDeintModes;
 
 // Deinterlacing processing mode
 typedef enum LAVDeintMode {
@@ -137,7 +137,7 @@ typedef enum LAVDeintMode {
   DeintMode_Aggressive,
   DeintMode_Force,
   DeintMode_Disable
-};
+} LAVDeintMode;
 
 // Type of deinterlacing to perform
 // - FramePerField re-constructs one frame from every field, resulting in 50/60 fps.
@@ -146,14 +146,14 @@ typedef enum LAVDeintMode {
 typedef enum LAVDeintOutput {
   DeintOutput_FramePerField,
   DeintOutput_FramePer2Field
-};
+} LAVDeintOutput;
 
 // Control the field order of the deinterlacer
 typedef enum LAVDeintFieldOrder {
   DeintFieldOrder_Auto,
   DeintFieldOrder_TopFieldFirst,
   DeintFieldOrder_BottomFieldFirst,
-};
+} LAVDeintFieldOrder;
 
 // Supported output pixel formats
 typedef enum LAVOutPixFmts {


### PR DESCRIPTION
Since all other enums were declared using C-style typedef I used that too for those that were incorrectly declared.

It seems like VS2013 missed those but VS2015 RC is pretty noisy about it (C4091 warnings).