### PR TITLE
LAV Splitter: Fix a crash when the pixel format is invalid.

### DIFF
--- a/demuxer/Demuxers/LAVFUtils.cpp
+++ b/demuxer/Demuxers/LAVFUtils.cpp
@@ -248,8 +248,8 @@ std::string lavf_get_stream_description(AVStream *pStream)
     // Codec
     buf << codec_name;
     // Pixel Format
-    if (enc->pix_fmt != AV_PIX_FMT_NONE) {
-      buf << ", " << av_get_pix_fmt_name(enc->pix_fmt);
+    if (char* pix_fmt = av_get_pix_fmt_name(enc->pix_fmt)) {
+      buf << ", " << pix_fmt;
     }
     // Dimensions
     if (enc->width) {


### PR DESCRIPTION
We got a report where this crashed because the pixel format was invalid so `av_get_pix_fmt_name` returned `NULL`. The patch is mostly here to illustrate the issue. Any idea how this could happen?