### PR TITLE
Support Visual Studio 2015.

### DIFF
--- a/common/platform.props
+++ b/common/platform.props
@@ -3,4 +3,7 @@
   <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '12.0'">
     <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(VisualStudioVersion)' == '14.0'">
+    <PlatformToolset>v140_xp</PlatformToolset>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hello,

I'm looking into Visual Studio 2015 support for MPC-HC so I tried to compile LAV Filters with it.

Here is the current state of what I did. The changes for the libbluray and qsdecoder submodules can be found here: https://gist.github.com/Underground78/2f5f47d733df78efd11f since you don't have those repos on GitHub.

As far as I can tell everything is working fine for LAV Filters itself and libbluray but there is a compilation issue with qsdecoder that I was not able to solve yet. It seems to be caused by linking the Intel SDK (libmfx). An external symbol (namely `_swscanf_s`) cannot be resolved. I have tried to manually link the CRT but to no avail. I am not sure what I am missing here so any thoughts are welcome.

U78