### PR TITLE
LAVVideo: use WMV9 DMO/MFT decoder to decode wmv1 and wmv2.

### DIFF
--- a/decoder/LAVVideo/DecodeThread.cpp
+++ b/decoder/LAVVideo/DecodeThread.cpp
@@ -444,7 +444,7 @@ softwaredec:
   if (!m_pDecoder) {
     DbgLog((LOG_TRACE, 10, L"-> No HW Codec, using Software"));
     m_bHWDecoder = FALSE;
-    if (m_pLAVVideo->GetUseMSWMV9Decoder() && (codec == AV_CODEC_ID_VC1 || codec == AV_CODEC_ID_WMV3) && !m_bWMV9Failed) {
+    if (m_pLAVVideo->GetUseMSWMV9Decoder() && (codec == AV_CODEC_ID_VC1 || codec == AV_CODEC_ID_WMV1 || codec == AV_CODEC_ID_WMV2 || codec == AV_CODEC_ID_WMV3) && !m_bWMV9Failed) {
       if (IsWindows7OrNewer())
         m_pDecoder = CreateDecoderWMV9MFT();
       else

--- a/decoder/LAVVideo/LAVVideo.rc
+++ b/decoder/LAVVideo/LAVVideo.rc
@@ -147,7 +147,7 @@ FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
     LTEXT           "Select which formats LAV Video should decode:",IDC_LBL_FORMATS,8,10,378,10
     CONTROL         "",IDC_CODECS,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,7,20,387,193
-    CONTROL         "Use Microsoft WMV9 DMO decoder for WMV3 and VC-1",IDC_CODECS_MSWMVDMO,
+    CONTROL         "Use Microsoft WMV9 DMO decoder for WMV1/2/3 and VC-1",IDC_CODECS_MSWMVDMO,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,230,352,10
     CONTROL         "Enable DVD Video support",IDC_DVD_VIDEO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,217,313,10
 END

--- a/decoder/LAVVideo/decoders/wmv9.cpp
+++ b/decoder/LAVVideo/decoders/wmv9.cpp
@@ -258,7 +258,11 @@ STDMETHODIMP CDecWMV9::Init()
 
 static GUID VerifySubtype(AVCodecID codec, GUID subtype)
 {
-  if (codec == AV_CODEC_ID_WMV3) {
+  if (codec == AV_CODEC_ID_WMV1) {
+    return MEDIASUBTYPE_WMV1;
+  } else if (codec == AV_CODEC_ID_WMV2) {
+    return MEDIASUBTYPE_WMV2;
+  } else if (codec == AV_CODEC_ID_WMV3) {
     return MEDIASUBTYPE_WMV3;
   } else {
     if ( subtype == MEDIASUBTYPE_WVC1

--- a/decoder/LAVVideo/decoders/wmv9mft.cpp
+++ b/decoder/LAVVideo/decoders/wmv9mft.cpp
@@ -128,7 +128,11 @@ STDMETHODIMP CDecWMV9MFT::Init()
 
 static GUID VerifySubtype(AVCodecID codec, GUID subtype)
 {
-  if (codec == AV_CODEC_ID_WMV3) {
+  if (codec == AV_CODEC_ID_WMV1) {
+    return MEDIASUBTYPE_WMV1;
+  } else if (codec == AV_CODEC_ID_WMV2) {
+    return MEDIASUBTYPE_WMV2;
+  } else if (codec == AV_CODEC_ID_WMV3) {
     return MEDIASUBTYPE_WMV3;
   } else {
     if (subtype == MEDIASUBTYPE_WVC1 || subtype == MEDIASUBTYPE_wvc1)


### PR DESCRIPTION
Is it necessary? 
I personally prefer the MFT decoder......