### PR TITLE
CDecWMV9MFT: Fix heap memory corruption when destroying Buffer struct.

### DIFF
--- a/decoder/LAVVideo/decoders/wmv9.h
+++ b/decoder/LAVVideo/decoders/wmv9.h
@@ -27,14 +27,14 @@
 
 class CVC1HeaderParser;
 
-typedef struct _Buffer {
-  BYTE *buffer = nullptr;
-  size_t size  = 0;
-  bool used    = false;
-} Buffer;
-
 class CDecWMV9 : public CDecBase
 {
+  typedef struct _Buffer {
+    BYTE *buffer = nullptr;
+    size_t size  = 0;
+    bool used    = false;
+  } Buffer;
+
 public:
   CDecWMV9(void);
   virtual ~CDecWMV9(void);

--- a/decoder/LAVVideo/decoders/wmv9mft.h
+++ b/decoder/LAVVideo/decoders/wmv9mft.h
@@ -45,14 +45,14 @@ typedef HRESULT STDAPICALLTYPE tMFAverageTimePerFrameToFrameRate(UINT64 unAverag
 
 class CVC1HeaderParser;
 
-typedef struct _Buffer {
-  IMFMediaBuffer *pBuffer = nullptr;
-  DWORD size              = 0;
-  bool used               = false;
-} Buffer;
-
 class CDecWMV9MFT : public CDecBase
 {
+  typedef struct _Buffer {
+    IMFMediaBuffer *pBuffer = nullptr;
+    DWORD size              = 0;
+    bool used               = false;
+  } Buffer;
+
 public:
   CDecWMV9MFT(void);
   virtual ~CDecWMV9MFT(void);


### PR DESCRIPTION
Raw pointers to interface is never good idea.
Also simplify the code a little.