### PR TITLE
Prevent audio buffer size integer overflows

### DIFF
--- a/common/DSUtilLite/growarray.h
+++ b/common/DSUtilLite/growarray.h
@@ -32,6 +32,10 @@
 #include <assert.h>
 #include "DShowUtil.h"
 
+#ifndef DWORD_MAX
+#define DWORD_MAX 4294967295
+#endif
+
 template <class T>
 class GrowableArray
 {


### PR DESCRIPTION
There are several silent signed vs unsigned casts without range checks in the audio buffering code. A partial fix was already applied with commit d0ed3091d514914ac2f8cf3b84790146eb3935ba. This is an improved version of that fix, where several variable datatypes have been corrected as well.