### PR TITLE
Allow sending empty samples to the FFmpeg decoders

### DIFF
--- a/decoder/LAVVideo/LAVVideo.cpp
+++ b/decoder/LAVVideo/LAVVideo.cpp
@@ -1391,11 +1391,6 @@ HRESULT CLAVVideo::Receive(IMediaSample *pIn)
 
   m_hrDeliver = S_OK;
 
-  // Skip over empty packets
-  if (pIn->GetActualDataLength() == 0) {
-    return S_OK;
-  }
-
   hr = m_Decoder.Decode(pIn);
   if (FAILED(hr))
     return hr;


### PR DESCRIPTION
Allowing empty media samples to reach the FFmpeg decoder cause the output of the frames remaining in the pipeline. 
This can be useful when video decoding is done one GOP at a time in order, for example, to enable reverse playback.

See https://ffmpeg.org/doxygen/3.2/group__lavc__decoding.html#ga3ac51525b7ad8bca4ced9f3446e96532 - first note