### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/decoder/LAVVideo/decoders/wmv9.cpp
+++ b/decoder/LAVVideo/decoders/wmv9.cpp
@@ -44,7 +44,7 @@ ILAVDecoder *CreateDecoderWMV9() {
 class CMediaBuffer : public IMediaBuffer, public INSSBuffer3
 {
 public:
-  CMediaBuffer(BYTE *pData, DWORD dwLength, bool bNSSBuffer) : m_pData(pData), m_dwLength(dwLength), m_dwMaxLength(dwLength), m_cRef(1), m_bNSSBuffer(bNSSBuffer), m_ContentType(0) {}
+  CMediaBuffer(BYTE *pData, DWORD dwLength, bool bNSSBuffer) : m_cRef(1), m_bNSSBuffer(bNSSBuffer), m_pData(pData), m_dwLength(dwLength), m_dwMaxLength(dwLength), m_ContentType(0) {}
   virtual ~CMediaBuffer() {}
 
   // IUnknown

--- a/demuxer/Demuxers/LAVFDemuxer.h
+++ b/demuxer/Demuxers/LAVFDemuxer.h
@@ -153,8 +153,8 @@ private:
   void CleanupAVFormat();
   void UpdateParserFlags(AVStream *st);
 
-  REFERENCE_TIME ConvertTimestampToRT(int64_t pts, int den, int num, int64_t starttime = (int64_t)AV_NOPTS_VALUE) const;
-  int64_t ConvertRTToTimestamp(REFERENCE_TIME timestamp, int den, int num, int64_t starttime = (int64_t)AV_NOPTS_VALUE) const;
+  REFERENCE_TIME ConvertTimestampToRT(int64_t pts, int num, int den, int64_t starttime = (int64_t)AV_NOPTS_VALUE) const;
+  int64_t ConvertRTToTimestamp(REFERENCE_TIME timestamp, int num, int den, int64_t starttime = (int64_t)AV_NOPTS_VALUE) const;
 
   int GetStreamIdxFromTotalIdx(size_t index) const;
   const CBaseDemuxer::stream* GetStreamFromTotalIdx(size_t index) const;

--- a/demuxer/LAVSplitter/OutputPin.cpp
+++ b/demuxer/LAVSplitter/OutputPin.cpp
@@ -30,10 +30,10 @@
 
 CLAVOutputPin::CLAVOutputPin(std::deque<CMediaType>& mts, LPCWSTR pName, CBaseFilter *pFilter, CCritSec *pLock, HRESULT *phr, CBaseDemuxer::StreamType pinType, const char* container)
   : CBaseOutputPin(NAME("lavf dshow output pin"), pFilter, pLock, phr, pName)
+  , m_mts(mts)
   , m_containerFormat(container)
   , m_pinType(pinType)
   , m_Parser(this, container)
-  , m_mts(mts)
 {
   SetQueueSizes();
 }


### PR DESCRIPTION
Did a round of scanning the project through cppcheck.
Those are the (relatively) significant ones, others are just coding style / pass-by-reference suggestions that I didn't bother changing it.
