### PR TITLE
Add compilation flags for better code generation.

### DIFF
--- a/common/DSUtilLite/DShowUtil.cpp
+++ b/common/DSUtilLite/DShowUtil.cpp
@@ -108,7 +108,7 @@ void DbgCloseLogFile()
 }
 #endif
 
-void split(std::string& text, std::string& separators, std::list<std::string>& words)
+void split(const std::string& text, const std::string& separators, std::list<std::string>& words)
 {
     size_t n = text.length();
     size_t start, stop;

--- a/common/DSUtilLite/DShowUtil.h
+++ b/common/DSUtilLite/DShowUtil.h
@@ -79,7 +79,7 @@ static CUnknown* WINAPI CreateInstance(LPUNKNOWN lpunk, HRESULT* phr)
 
 extern void SetThreadName( DWORD dwThreadID, LPCSTR szThreadName);
 
-void split(std::string& text, std::string& separators, std::list<std::string>& words);
+void split(const std::string& text, const std::string& separators, std::list<std::string>& words);
 
 // Filter Registration
 extern void RegisterSourceFilter(const CLSID& clsid, const GUID& subtype2, LPCWSTR chkbytes, ...);

--- a/common/common.props
+++ b/common/common.props
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> 
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='DebugRelease'">
     <OutDir>$(SolutionDir)bin_$(PlatformName)d\lib\</OutDir>
@@ -11,7 +11,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)common\includes;$(SolutionDir)common\baseclasses;$(SolutionDir)ffmpeg;$(SolutionDir)libbluray\src;$(SolutionDir)common\DSUtilLite;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/Zc:inline /Zc:rvalueCast /Zc:throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/std:c++latest /Zc:inline,referenceBinding,rvalueCast,throwingNew %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(PlatformToolsetVersion)' != '140'">/Zc:ternary %(AdditionalOptions)</AdditionalOptions>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>

--- a/decoder/LAVAudio/Bitstream.cpp
+++ b/decoder/LAVAudio/Bitstream.cpp
@@ -284,7 +284,7 @@ void CLAVAudio::ActivateDTSHDMuxing()
   m_bDTSHD = TRUE;
 
   // Check if downstream actually accepts it..
-  CMediaType &mt = CreateBitstreamMediaType(m_nCodecId, m_bsParser.m_dwSampleRate);
+  const CMediaType &mt = CreateBitstreamMediaType(m_nCodecId, m_bsParser.m_dwSampleRate);
   HRESULT hr = m_pOutput->GetConnected()->QueryAccept(&mt);
   if (hr != S_OK) {
     DbgLog((LOG_TRACE, 20, L"-> But downstream doesn't want DTS-HD, sticking to DTS core"));


### PR DESCRIPTION
- Enable LTCG for better devirtualization and code optimization.
- Do not use TR namespace for already supported features in standard
library
- Enable /Gw (Optimize Global Data)
- Use 3 iterantions for COMDAT folding as it gives noticable improvment
over default two iterations.
- Add /Zc:referenceBinding,strictStrings,ternary to enforce C++ standard
conformant code. Fix few minor issues in the code.