### PR TITLE
Fallback to decoding audio if bitstreaming fails option

### DIFF
--- a/decoder/LAVAudio/AudioSettingsProp.cpp
+++ b/decoder/LAVAudio/AudioSettingsProp.cpp
@@ -177,7 +177,7 @@ HRESULT CLAVAudioSettingsProp::OnActivate()
     addHint(IDC_BS_DTSHD_FRAMING, L"With some Receivers, this setting might be needed to achieve the full features of DTS. However, on other Receivers, this option will cause DTS to not work at all.\n\nIf you do not experience any problems, its recommended to leave this setting untouched.");
 	
     SendDlgItemMessage(m_Dlg, IDC_BS_FALLBACK, BM_SETCHECK, m_bBitstreamingFallback, 0);
-	  addHint(IDC_BS_FALLBACK, L"Fallback to audio decoding if bitstreaming is not supported by the audio renderer/hardware.");
+    addHint(IDC_BS_FALLBACK, L"Fallback to audio decoding if bitstreaming is not supported by the audio renderer/hardware.");
     
     SendDlgItemMessage(m_Dlg, IDC_AUTO_AVSYNC, BM_SETCHECK, m_bAutoAVSync, 0);
     addHint(IDC_AUTO_AVSYNC, L"Enables automatic tracking and correction of A/V sync.\n\nIf you encounter any sync issues, disabling this option can help in debugging the source of the problem.");
@@ -281,9 +281,9 @@ INT_PTR CLAVAudioSettingsProp::OnReceiveMessage(HWND hwnd, UINT uMsg, WPARAM wPa
       if (bFlag != m_bDTSHDFraming)
         SetDirty();
     } else if (LOWORD(wParam) == IDC_BS_FALLBACK && HIWORD(wParam) == BN_CLICKED) {
-		  BOOL bFlag = (BOOL)SendDlgItemMessage(m_Dlg, LOWORD(wParam), BM_GETCHECK, 0, 0);
-		  if (bFlag != m_bBitstreamingFallback)
-			  SetDirty();
+      BOOL bFlag = (BOOL)SendDlgItemMessage(m_Dlg, LOWORD(wParam), BM_GETCHECK, 0, 0);
+      if (bFlag != m_bBitstreamingFallback)
+        SetDirty();
     } else if (LOWORD(wParam) == IDC_AUTO_AVSYNC && HIWORD(wParam) == BN_CLICKED) {
       BOOL bFlag = (BOOL)SendDlgItemMessage(m_Dlg, LOWORD(wParam), BM_GETCHECK, 0, 0);
       if (bFlag != m_bAutoAVSync)

--- a/decoder/LAVAudio/AudioSettingsProp.h
+++ b/decoder/LAVAudio/AudioSettingsProp.h
@@ -71,6 +71,7 @@ private:
 
   bool m_bBitstreaming[Bitstream_NB];
   BOOL m_bDTSHDFraming;
+  BOOL m_bBitstreamingFallback;
   BOOL m_bAutoAVSync;
   BOOL m_bOutputStdLayout;
   BOOL m_bOutput51Legacy;

--- a/decoder/LAVAudio/Bitstream.cpp
+++ b/decoder/LAVAudio/Bitstream.cpp
@@ -483,7 +483,7 @@ HRESULT CLAVAudio::DeliverBitstream(AVCodecID codec, const BYTE *buffer, DWORD d
       UpdateBitstreamContext();
       goto done;
     }
-    else if (hr == S_FALSE)
+    else if (hr == S_FALSE && m_settings.bBitstreamingFallback == TRUE)
     {
       BitstreamFallbackToPCM();
       goto done;

--- a/decoder/LAVAudio/LAVAudio.cpp
+++ b/decoder/LAVAudio/LAVAudio.cpp
@@ -243,7 +243,7 @@ HRESULT CLAVAudio::ReadSettings(HKEY rootKey)
     if (SUCCEEDED(hr)) m_settings.DTSHDFraming = bFlag;
 
     bFlag = reg.ReadBOOL(L"BitstreamingFallback", hr);
-	  if (SUCCEEDED(hr)) m_settings.bBitstreamingFallback = bFlag;
+    if (SUCCEEDED(hr)) m_settings.bBitstreamingFallback = bFlag;
 
     bFlag = reg.ReadBOOL(L"AutoAVSync", hr);
     if (SUCCEEDED(hr)) m_settings.AutoAVSync = bFlag;
@@ -962,7 +962,7 @@ HRESULT CLAVAudio::GetMediaType(int iPosition, CMediaType *pMediaType)
 
   if (m_avBSContext) {
     if (iPosition > 0 && m_settings.bBitstreamingFallback == FALSE)
-	    return VFW_S_NO_MORE_ITEMS;
+      return VFW_S_NO_MORE_ITEMS;
 
     if (iPosition == 0) {
       *pMediaType = CreateBitstreamMediaType(m_nCodecId, m_pAVCtx->sample_rate, TRUE);

--- a/decoder/LAVAudio/LAVAudio.cpp
+++ b/decoder/LAVAudio/LAVAudio.cpp
@@ -160,6 +160,7 @@ HRESULT CLAVAudio::LoadDefaults()
   memset(m_settings.bBitstream, 0, sizeof(m_settings.bBitstream));
 
   m_settings.DTSHDFraming         = FALSE;
+  m_settings.bBitstreamingFallback= TRUE;
   m_settings.AutoAVSync           = TRUE;
   m_settings.ExpandMono           = FALSE;
   m_settings.Expand61             = FALSE;
@@ -240,6 +241,9 @@ HRESULT CLAVAudio::ReadSettings(HKEY rootKey)
 
     bFlag = reg.ReadBOOL(L"DTSHDFraming", hr);
     if (SUCCEEDED(hr)) m_settings.DTSHDFraming = bFlag;
+
+    bFlag = reg.ReadBOOL(L"BitstreamingFallback", hr);
+	  if (SUCCEEDED(hr)) m_settings.bBitstreamingFallback = bFlag;
 
     bFlag = reg.ReadBOOL(L"AutoAVSync", hr);
     if (SUCCEEDED(hr)) m_settings.AutoAVSync = bFlag;
@@ -335,6 +339,7 @@ HRESULT CLAVAudio::SaveSettings()
     reg.WriteBOOL(L"DRCEnabled", m_settings.DRCEnabled);
     reg.WriteDWORD(L"DRCLevel", m_settings.DRCLevel);
     reg.WriteBOOL(L"DTSHDFraming", m_settings.DTSHDFraming);
+    reg.WriteBOOL(L"BitstreamingFallback", m_settings.bBitstreamingFallback);
     reg.WriteBOOL(L"AutoAVSync", m_settings.AutoAVSync);
     reg.WriteBOOL(L"ExpandMono", m_settings.ExpandMono);
     reg.WriteBOOL(L"Expand61", m_settings.Expand61);
@@ -546,6 +551,11 @@ STDMETHODIMP_(BOOL) CLAVAudio::GetDTSHDFraming()
   return m_settings.DTSHDFraming;
 }
 
+STDMETHODIMP_(BOOL) CLAVAudio::GetBitstreamingFallback()
+{
+	return m_settings.bBitstreamingFallback;
+}
+
 STDMETHODIMP CLAVAudio::SetDTSHDFraming(BOOL bHDFraming)
 {
   m_settings.DTSHDFraming = bHDFraming;
@@ -555,6 +565,14 @@ STDMETHODIMP CLAVAudio::SetDTSHDFraming(BOOL bHDFraming)
     m_bBitStreamingSettingsChanged = TRUE;
 
   return S_OK;
+}
+
+STDMETHODIMP CLAVAudio::SetBitstreamingFallback(BOOL bBitstreamingFallback)
+{
+	m_settings.bBitstreamingFallback = bBitstreamingFallback;
+	SaveSettings();
+
+	return S_OK;
 }
 
 STDMETHODIMP_(BOOL) CLAVAudio::GetAutoAVSync()
@@ -943,6 +961,9 @@ HRESULT CLAVAudio::GetMediaType(int iPosition, CMediaType *pMediaType)
   }
 
   if (m_avBSContext) {
+    if (iPosition > 0 && m_settings.bBitstreamingFallback == FALSE)
+	    return VFW_S_NO_MORE_ITEMS;
+
     if (iPosition == 0) {
       *pMediaType = CreateBitstreamMediaType(m_nCodecId, m_pAVCtx->sample_rate, TRUE);
       return S_OK;
@@ -1494,7 +1515,7 @@ HRESULT CLAVAudio::CheckConnect(PIN_DIRECTION dir, IPin *pPin)
 HRESULT CLAVAudio::CompleteConnect(PIN_DIRECTION dir, IPin *pReceivePin)
 {
   DbgLog((LOG_TRACE, 5, L"CompleteConnect -- %S", dir == PINDIR_INPUT ? "in" : "out"));
-  if (dir == PINDIR_OUTPUT)
+  if (dir == PINDIR_OUTPUT && m_settings.bBitstreamingFallback == TRUE)
   {
     // check that we connected with a bitstream type, or go back to decoding otherwise
     if (m_avBSContext) {

--- a/decoder/LAVAudio/LAVAudio.h
+++ b/decoder/LAVAudio/LAVAudio.h
@@ -296,7 +296,7 @@ private:
     BOOL bFormats[Codec_AudioNB];
     BOOL bBitstream[Bitstream_NB];
     BOOL DTSHDFraming;
-	  BOOL bBitstreamingFallback;
+    BOOL bBitstreamingFallback;
     BOOL AutoAVSync;
     BOOL ExpandMono;
     BOOL Expand61;

--- a/decoder/LAVAudio/LAVAudio.h
+++ b/decoder/LAVAudio/LAVAudio.h
@@ -103,6 +103,8 @@ public:
   STDMETHODIMP SetBitstreamConfig(LAVBitstreamCodec bsCodec, BOOL bEnabled);
   STDMETHODIMP_(BOOL) GetDTSHDFraming();
   STDMETHODIMP SetDTSHDFraming(BOOL bHDFraming);
+  STDMETHODIMP_(BOOL) GetBitstreamingFallback();
+  STDMETHODIMP SetBitstreamingFallback(BOOL bBitstreamingFallback);
   STDMETHODIMP_(BOOL) GetAutoAVSync();
   STDMETHODIMP SetAutoAVSync(BOOL bAutoSync);
   STDMETHODIMP_(BOOL) GetOutputStandardLayout();
@@ -294,6 +296,7 @@ private:
     BOOL bFormats[Codec_AudioNB];
     BOOL bBitstream[Bitstream_NB];
     BOOL DTSHDFraming;
+	  BOOL bBitstreamingFallback;
     BOOL AutoAVSync;
     BOOL ExpandMono;
     BOOL Expand61;

--- a/decoder/LAVAudio/LAVAudio.rc
+++ b/decoder/LAVAudio/LAVAudio.rc
@@ -28,6 +28,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // remains consistent on all systems.
 IDI_ICON1               ICON                    "..\\..\\resources\\blue.ico"
 
+
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -63,7 +64,7 @@ END
 // Dialog
 //
 
-IDD_PROPPAGE_AUDIO_SETTINGS DIALOGEX 0, 0, 369, 224
+IDD_PROPPAGE_AUDIO_SETTINGS DIALOGEX 0, 0, 369, 234
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_CHILD
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
@@ -73,7 +74,7 @@ BEGIN
     CONTROL         "",IDC_DRC_LEVEL,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,50,30,100,12
     LTEXT           "Level: ",IDC_LBL_DRC_LEVEL,15,30,28,8
     LTEXT           "100%",IDC_DRC_LEVEL_TEXT,150,30,20,8,0,WS_EX_RIGHT
-    GROUPBOX        "Bitstreaming (S/PDIF, HDMI)",IDC_BITSTREAMING,7,50,196,88
+    GROUPBOX        "Bitstreaming (S/PDIF, HDMI)",IDC_BITSTREAMING,7,50,196,98
     LTEXT           "Formats",IDC_BS_FORMATS,12,60,122,8
     CONTROL         "Dolby Digital (AC-3)",IDC_BS_AC3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,72,79,10
     CONTROL         "Dolby Digital Plus (E-AC3)",IDC_BS_EAC3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,86,97,10
@@ -83,14 +84,15 @@ BEGIN
     LTEXT           "Options",IDC_BS_OPTIONS,12,112,26,8
     CONTROL         "Force max DTS-HD rate (not recommended)",IDC_BS_DTSHD_FRAMING,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,123,151,10
-    GROUPBOX        "Options",IDC_OPTIONS,7,139,196,65
-    CONTROL         "Auto A/V Sync correction",IDC_AUTO_AVSYNC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,150,96,10
+    GROUPBOX        "Options",IDC_OPTIONS,7,149,196,65
+    CONTROL         "Auto A/V Sync correction",IDC_AUTO_AVSYNC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,160,96,10
     CONTROL         "Convert Output to Standard Channel Layouts",IDC_STANDARD_CH_LAYOUT,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,164,162,10
-    CONTROL         "Expand Mono to Stereo",IDC_EXPAND_MONO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,178,91,10
-    CONTROL         "Expand 6.1 to 7.1",IDC_EXPAND61,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,118,178,74,10
-    CONTROL         "Use Legacy 5.1 channel layout",IDC_OUTPUT51_LEGACY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,192,162,10
-    LTEXT           "LAV Audio Decoder x.xx",IDC_LAVAUDIO_FOOTER,209,211,149,8,0,WS_EX_RIGHT
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,174,162,10
+    CONTROL         "Expand Mono to Stereo",IDC_EXPAND_MONO,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,188,91,10
+    CONTROL         "Expand 6.1 to 7.1",IDC_EXPAND61,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,118,188,74,10
+    CONTROL         "Use Legacy 5.1 channel layout",IDC_OUTPUT51_LEGACY,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,15,202,162,10
+    LTEXT           "LAV Audio Decoder x.xx",IDC_LAVAUDIO_FOOTER,209,221,149,8,0,WS_EX_RIGHT
     GROUPBOX        "Output Formats",IDC_OUTPUT_FORMATS,207,59,151,132
     LTEXT           "Select which output formats are available.\nThe best format is used automatically.",IDC_LBL_OUTPUTFORMATS,213,70,140,22
     CONTROL         "16-bit Integer",IDC_OUT_S16,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,216,91,61,10
@@ -106,7 +108,9 @@ BEGIN
     LTEXT           "Delay (in ms):",IDC_STATIC,213,37,47,8
     EDITTEXT        IDC_DELAY,261,35,46,13,ES_AUTOHSCROLL,WS_EX_RIGHT
     CONTROL         "",IDC_DELAYSPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | UDS_NOTHOUSANDS | UDS_HOTTRACK,305,35,11,13
-    CONTROL         "Enable System Tray Icon",IDC_TRAYICON,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,209,192,10
+    CONTROL         "Enable System Tray Icon",IDC_TRAYICON,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,219,192,10
+    CONTROL         "Fallback if bitstreaming is not supported",IDC_BS_FALLBACK,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,135,151,10
 END
 
 IDD_PROPPAGE_AUDIO_MIXING DIALOGEX 0, 0, 369, 215
@@ -200,7 +204,7 @@ BEGIN
         LEFTMARGIN, 7
         RIGHTMARGIN, 358
         TOPMARGIN, 7
-        BOTTOMMARGIN, 219
+        BOTTOMMARGIN, 229
     END
 
     IDD_PROPPAGE_AUDIO_MIXING, DIALOG
@@ -228,7 +232,6 @@ BEGIN
     END
 END
 #endif    // APSTUDIO_INVOKED
-
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/decoder/LAVAudio/LAVAudioSettings.h
+++ b/decoder/LAVAudio/LAVAudioSettings.h
@@ -193,7 +193,7 @@ interface __declspec(uuid("4158A22B-6553-45D0-8069-24716F8FF171")) ILAVAudioSett
   // Use 5.1 legacy layout (using back channels instead of side)
   STDMETHOD_(BOOL, GetOutput51LegacyLayout)() = 0;
   STDMETHOD(SetOutput51LegacyLayout)(BOOL b51Legacy) = 0;
-  
+
   // Fallback to audio decoding if bitstreaming is not supported by the audio renderer/hardware
   STDMETHOD_(BOOL, GetBitstreamingFallback)() = 0;
   STDMETHOD(SetBitstreamingFallback)(BOOL bBitstreamingFallback) = 0;

--- a/decoder/LAVAudio/LAVAudioSettings.h
+++ b/decoder/LAVAudio/LAVAudioSettings.h
@@ -193,6 +193,10 @@ interface __declspec(uuid("4158A22B-6553-45D0-8069-24716F8FF171")) ILAVAudioSett
   // Use 5.1 legacy layout (using back channels instead of side)
   STDMETHOD_(BOOL, GetOutput51LegacyLayout)() = 0;
   STDMETHOD(SetOutput51LegacyLayout)(BOOL b51Legacy) = 0;
+  
+  // Fallback to audio decoding if bitstreaming is not supported by the audio renderer/hardware
+  STDMETHOD_(BOOL, GetBitstreamingFallback)() = 0;
+  STDMETHOD(SetBitstreamingFallback)(BOOL bBitstreamingFallback) = 0;
 };
 
 // LAV Audio Status Interface

--- a/decoder/LAVAudio/resource.h
+++ b/decoder/LAVAudio/resource.h
@@ -108,6 +108,7 @@
 #define IDC_TRAYICON                    1131
 #define IDC_OUT_S16_DITHER              1132
 #define IDC_OUTPUT51_LEGACY             1133
+#define IDC_BS_FALLBACK                 1135
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
Hi,

I have issue with new feature that called “Fallback to decoding audio if bitstreaming fails”.
I use MPC-BE v1.8.2 x86, LAVFilters v0.72 and ReClock v1.9.0.7.

ReClock configuration:
![image](https://user-images.githubusercontent.com/4432037/46199137-f2806e00-c316-11e8-8b65-fe63b7a6affa.png)

1.  When Audio PCM detected – use ReClock WASAPI Exclusive Renderer.
2.  **When Audio Bitstream detected – switch to Windows build-in DirectSound Renderer.**

The problem is that with LAVFilters v0.72 – only option number 1 is working (all formats are decoding to PCM even if bitstreaming was enabled), because bitstreaming always fails.

So I added option to disable this feature:
![image](https://user-images.githubusercontent.com/4432037/46199241-3a9f9080-c317-11e8-8ac5-7372739dc0a3.png)

Do you have another solution for this issue? 