### PR TITLE
Do not create uninstall shortcut in start menu

### DIFF
--- a/LAVFilters.iss
+++ b/LAVFilters.iss
@@ -117,7 +117,6 @@ Name: {group}\LAV Video Configuration;           Filename: rundll32.exe; Paramet
 Name: {group}\LAV Video Configuration;           Filename: rundll32.exe; Parameters: """{app}\x64\LAVVideo.ax"",OpenConfiguration"; WorkingDir: {app}\x64; IconFilename: {app}\x64\LAVVideo.ax; IconIndex: 0; Tasks: icons; Components: lavvideo64 AND NOT lavvideo32
 Name: {group}\Visit LAV Filters Home Page;       Filename: "https://1f0.de/"; Tasks: icons
 Name: {group}\Visit LAV Filters on Doom9;        Filename: "https://forum.doom9.org/showthread.php?t=156191"; Tasks: icons
-Name: {group}\Uninstall LAV Filters;             Filename: {uninstallexe}; Tasks: icons
 
 [Registry]
 Root: HKCU; Subkey: Software\LAV;                  Flags: uninsdeletekeyifempty


### PR DESCRIPTION
Creating such a start menu entry is a leftover of the ancient Win 3.x time where there was no central control panel for removing programs.

Also see the Windows guidelines, where creating an uninstall shortcut is discouraged: https://msdn.microsoft.com/en-us/library/ms954377.aspx