### PR TITLE
Added a timeout on av_read_frame in LAVFDemuxer.cpp

### DIFF
--- a/demuxer/Demuxers/LAVFDemuxer.cpp
+++ b/demuxer/Demuxers/LAVFDemuxer.cpp
@@ -1437,6 +1437,7 @@ STDMETHODIMP CLAVFDemuxer::GetNextPacket(Packet **ppPacket)
         m_avFormat->pb->eof_reached = 0;
     }
 
+    m_timeOpening = time(nullptr);
     int result = 0;
     try
     {
@@ -1446,6 +1447,7 @@ STDMETHODIMP CLAVFDemuxer::GetNextPacket(Packet **ppPacket)
     {
         // ignore..
     }
+    m_timeOpening = 0;
 
     if (result == AVERROR(EINTR) || result == AVERROR(EAGAIN))
     {


### PR DESCRIPTION
Fixed a bug where the demuxer would get stuck on av_read_frame in LAVFDemuxer.cpp:GetNextPacket.

Repro steps:
1. Connect to a rtsp stream source
2. Disconnect the rtsp source (e.g. pull the power)
3. Watch how demuxer is perpetually stuck on av_read_frame